### PR TITLE
Fix factorization of nonmonic polynomials

### DIFF
--- a/src/elliptic/poly.py
+++ b/src/elliptic/poly.py
@@ -472,13 +472,17 @@ class PolyModular(BasePoly, metaclass=MetaPoly):
         """
         Return the distinct-degree factors of the polynomial with their irreducible degree.
 
-        The polynomial must be monic and square-free. The returned dictionary `{d: f, ...}` is a
+        The polynomial must be square-free. The returned dictionary `{d: f, ...}` is a
         factorization of the polynomial such that each factor *f* is a product of monic, irreducible
         polynomials of equal degree *d*.
         """
+        if self.leading and self.leading != 1:
+            r = {0: type(self)([self.leading])}
+            self = self.monic
+        else:
+            r = {}
 
         # Gauss' algorithm
-        r: dict[int, Self] = {}
         i = 1
         while self.deg > 2 * i - 1:  # Find all distinct-degree factors
             # Gauss' lemma: the product of all monic irreducible
@@ -499,6 +503,8 @@ class PolyModular(BasePoly, metaclass=MetaPoly):
 
         The polynomial must be a monic, square-free product of equal-degree irreducible factors.
         """
+        if d == 0:
+            return [self]
         nfacts, zero = divmod(self.deg, d)
         assert zero == 0, "EDF requires an equal-degree product"
         assert nfacts > 1, "EDF requires at least two factors"
@@ -535,8 +541,8 @@ class PolyModular(BasePoly, metaclass=MetaPoly):
         return {
             factor: exponent
             for squarefree, exponent in self.sff().items()
-            for deg, equaldeg in squarefree.monic.ddf().items()
-            for factor in (equaldeg.monic.edf(deg) if deg < equaldeg.deg else [equaldeg.monic])
+            for deg, equaldeg in squarefree.ddf().items()
+            for factor in (equaldeg.monic.edf(deg) if deg < equaldeg.deg else [equaldeg])
         }
 
     def sqrt(self) -> Self | None:

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -162,8 +162,11 @@ class TestPolyModular(TestCase):
     def test_factors(self) -> None:
         P: type[PolyModular] = PolyModular[3]
         p1, p2 = P.from_string("X + 1"), P.from_string("X + 2")
+        self.assertEqual(p1.factors(), {p1: 1})
         p = p1 * p2
         self.assertEqual(p.factors(), {p1: 1, p2: 1})
+        q = P.M(2)
+        self.assertEqual((q @ p1).factors(), {P([q]): 1, p1: 1})
         for m in [2, 3, 5, 7]:
             P = PolyModular[m]
             p = P.from_string("X**11 + 2*X**9 + 2*X**8 + X**6 + X**5 + 2*X**3 + 2*X**2 + 1")


### PR DESCRIPTION
This fixes a bug in `poly.PolyModular.factors()` which would be missing the constant factor for nonmonic polynomials.

As a side-effect, `poly.PolyModular.ddf()` now works on squarefree nonmonic polynomials.
