### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build documentation
       run: make doc
     - name: Upload documentation
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: docs/
   package:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Build package distribution
       run: make package
     - name: Upload package distribution
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: distribution
         path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v4
     - name: Set up
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Run linter
@@ -38,7 +38,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v4
     - name: Set up
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Build documentation
@@ -55,7 +55,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v4
     - name: Set up
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Auto format code


### PR DESCRIPTION
This updates GitHub Actions to use Node.js 20 as version 16 is deprecated:
- https://github.com/actions/setup-python
- https://github.com/actions/upload-artifact
- https://github.com/actions/upload-pages-artifact

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.