### PR TITLE
Do not autoformat before packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
-    - name: Auto format code
-      run: make format
     - name: Build package distribution
       run: make package
     - name: Upload package distribution


### PR DESCRIPTION
This removes the call to `make format` before building the package distribution.