### PR TITLE
Use benv to build package distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ get_url = from tomllib import loads; print(loads(open("pyproject.toml").read().s
 .PHONY: package doc format lint type test clean
 
 package: $(BUILD_DIR) $(BUILD_VENV)
-	$(VENV)/bin/python -m build -o $(BUILD_DIR) .
+	$(BUILD_VENV)/bin/python -m build -o $(BUILD_DIR) .
 
 doc: $(DOC_DIR) $(VENV)
 	cp $(LOGO_FILE) $(DOC_DIR)/$(LOGO_FILE)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(DOC_DIR):
 
 $(BUILD_VENV): $(SETUP_FILES)
 	$(python) -m venv $(BUILD_VENV)
-	$(BUILD_VENV)/bin/pip install -U pip
+	$(BUILD_VENV)/bin/pip install -U pip build
 	touch $(BUILD_VENV)
 
 $(VENV): $(SETUP_FILES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Homepage = "https://github.com/ncanceill/elliptic_curves"
 Documentation = "https://ncanceill.github.io/elliptic_curves"
 
 [project.optional-dependencies]
-dev = ["build", "setuptools", "setuptools-scm"]
+dev = ["setuptools", "setuptools-scm"]
 doc = ["pdoc"]
 quality = ["black", "flake8", "Flake8-pyproject", "isort"]
 testing = ["mypy", "types-setuptools"]


### PR DESCRIPTION
This fixes the Makefile target `package` to use the dedicated `benv` virtual environment.

This also removes the `build` package from optional dependencies and installs it in `benv` instead.